### PR TITLE
Ajout de l'ENT educ de normandie

### DIFF
--- a/src/ent_list.json
+++ b/src/ent_list.json
@@ -239,6 +239,12 @@
       "url": "cas.ent.auvergnerhonealpes.fr",
       "py": "ent_auvergnerhonealpe"
     },
+        {
+      "name": "ENT l'Éduc de Normandie via EduConnect",
+      "cas": "educ-normandie",
+      "url": "connexion.l-educdenormandie.fr",
+      "py": "educ-normandie"
+    },
     {
       "name": "Pas d'ENT",
       "cas": "",


### PR DESCRIPTION
Ajout de l'ENT L'Éduc de Normandie. Cela contribue également à l'issue #26 