### PR TITLE
refactor: remove jQuery and use native functions

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,6 @@
         <!-- splash screens -->
         <link rel="apple-touch-startup-image" media="(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)" href="/splash/launch-828x1792.jpg" />
 
-
-        <!-- virez moi ça le plus vite possible -->
-        <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-
         <!-- status bar -->
         <meta name="theme-color" content="#f4f4f4" media="(prefers-color-scheme: light)">
         <meta name="theme-color" content="#0f0f0f" media="(prefers-color-scheme: dark)">

--- a/public/src/App.js
+++ b/public/src/App.js
@@ -149,8 +149,10 @@ function emptyCache(automatic) {
 }
 
 /* decode HTML string */
-function decodeHtml(html) {
-    return $('<div>').html(html).text();
+function decodeHtml (html) {
+    const textArea = document.createElement("textarea");
+    textArea.innerHTML = html;
+    return textArea.value;
 }
 
 /* get basic user data */


### PR DESCRIPTION
En tant que partisan **anti-jQuery**, je me devais de faire ce pull-request même si Pronote+ est un concurrent à [mon projet Pornote](https://github.com/Vexcited/Pornote).

Ce serait trahison de ne pas vous partager les bien faits d'utiliser [`fetch`](https://developer.mozilla.org/fr/docs/Web/API/Fetch_API) à la place d'axios.

Bien qu'axios soit une belle librairie, il est inutile de bourrer le bundle JS de son application avec des librairies qui font exactement la même chose que des fonctions disponibles de manière native. J'avoue par contre que j'ai remplacé `axios` par `fetch` uniquement dans l'étape 2 du login, je l'ai fait en même temps que jQuery.

J'espère n'avoir pas oublié de remplacer des fonctions utilisant jQuery, j'ai essayé de faire de mon mieux.

J'ai aussi factorisé quelques morceaux de code pour utiliser `async/await`, il ne faut pas oublier l'utilité des Promises et du `try/catch/finally` :D

S'il y a des questions, n'hésitez pas à les poser, j'y répondrais.