### PR TITLE
Changements des textes : Pronote+ -> Papillon

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@
 Parce qu'il me fallait une alternative à l'app officielle qui commence vraiment à se faire vieille...
 
 ## Screenshots
-
+<!-- Logo à changer -->
 ![image](https://user-images.githubusercontent.com/32978709/205466858-7a17fb9f-feb1-46d0-a4a7-d8aec94e1cd0.png)
 
 ## Fonctionnalités
 
-* **Fonctionnalités de Pronote**
+* **Fonctionnalités de Papillon**
     - 📆 Emploi du temps
         + Organisation intuitive du temps
         + Ajout au calendrier
@@ -55,7 +55,7 @@ Parce qu'il me fallait une alternative à l'app officielle qui commence vraiment
 - [Tryon](https://github.com/tryon-dev)
 - [Astrow25](https://github.com/Astrow25)
 
-## Alternatives à Pronote+
+## Alternatives à Papillon
 Effectivement on a des concurrents, et c'est important de les soutenir vu qu'on connait la galère de faire un client Pronote.
 
 - [⭐️ Pornote](https://github.com/Vexcited/pornote)

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
     <head>
         <meta charset="UTF-8">
-        <title>Pronote+ Beta</title>
+        <title>Papillon Beta</title>
 
         <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover user-scalable=no">
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,9 +4,9 @@
     "display": "standalone",
     "scope": "/",
     "start_url": "/",
-    "name": "Pronote+",
-    "description": "L'app de vie scolaire intelligente",
-    "short_name": "Pronote+",
+    "name": "Papillon",
+    "description": "Votre vie scolaire",
+    "short_name": "Papillon",
     "icons": [
         {
             "src": "img/icons/icon-192x192.png",

--- a/src/views/AboutTab.vue
+++ b/src/views/AboutTab.vue
@@ -39,11 +39,11 @@
 </script>
 
 <template>
-    <TabName name="À propos de Pronote+" logged />
+    <TabName name="À propos de Papillon" logged />
     <div id="content">
         
         <div class="generique">
-            <img src="/logo_shaded.svg" class="logo" alt="Logo Pronote+">
+            <img src="/logo_shaded.svg" class="logo" alt="Logo Papillon">
             <small>Papillon v{{ version }} / Papillon-Python v{{ api_version }}</small>
         </div>
 
@@ -57,7 +57,7 @@
                 <h3>Vince Linise</h3>
                 <small>@ecnivtwelve</small>
 
-                <p>Créateur et développeur principal de l'application et du serveur Pronote+</p>
+                <p>Créateur et développeur principal de l'application et du serveur Papillon</p>
             </template>
         </MainItem>
 
@@ -93,7 +93,7 @@
                 <h3>Tryon</h3>
                 <small>@tryon-dev</small>
 
-                <p>Maintainer principal de l'architecture serveur du projet Pronote+</p>
+                <p>Maintainer principal de l'architecture serveur du projet Papillon</p>
             </template>
         </MainItem>
 

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -167,7 +167,7 @@
         <div class="setting">
             <div class="settingName">
                 <h3>Couleur de l'interface</h3>
-                <p class="settingDescription">Choisissez la couleur de l'interface de Pronote+</p>
+                <p class="settingDescription">Choisissez la couleur de l'interface de Papillon</p>
             </div>
             <div class="settingValue">
                 <input type="color" id="brand-color" />
@@ -177,7 +177,7 @@
         <div class="setting">
             <div class="settingName">
                 <h3>Police de l'interface</h3>
-                <p class="settingDescription">Choisissez la police d'écriture de l'interface de Pronote+</p>
+                <p class="settingDescription">Choisissez la police d'écriture de l'interface de Papillon</p>
             </div>
             <div class="settingValue">
                 <select id="brandFont">
@@ -246,7 +246,7 @@
                 <LogOut />
             </template>
             <template #content>
-                <h3>Se déconnecter de Pronote+</h3>
+                <h3>Se déconnecter de Papillon</h3>
                 <p>Éfface toutes vos données Pronote de l'application</p>
             </template>
         </MainItem>
@@ -278,8 +278,8 @@
                 <Bug />
             </template>
             <template #content>
-                <h3>A propos de Pronote+</h3>
-                <p>Vous utilisez une version expérimentale de Pronote+ (version {{version}})</p>
+                <h3>A propos de Papillon</h3>
+                <p>Vous utilisez une version expérimentale de Papillon (version {{version}})</p>
             </template>
         </MainItem>
 

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -226,7 +226,7 @@
             </template>
             <template #content>
                 <h3>Réinitialiser les paramètres</h3>
-                <p>Rétablit les paramètres par défaut sans vous déconnecter de Pronote +</p>
+                <p>Rétablit les paramètres par défaut sans vous déconnecter de Papillon</p>
             </template>
         </MainItem>
 

--- a/src/views/login/SetupOne.vue
+++ b/src/views/login/SetupOne.vue
@@ -32,7 +32,7 @@
             <a class="terms" href="https://pronote.plus/assets/terms_privacy_23112022_rev0.pdf" v-wave>Termes & conditions</a>
         </div>
 
-        <h1>Bienvenue dans Pronote+ 👋</h1>
+        <h1>Bienvenue dans Papillon 👋</h1>
         <p class="desc">Sélectionnez une méthode de connexion à votre compte Pronote.</p>
 
         <div class="list group">


### PR DESCRIPTION
Du fait du changement de nom ["annoncé" sur le Discord](https://discord.com/channels/1014931881906675712/1014932976636809316/1059572972014276689), j'ai fait de mon mieux pour changer les mentions de `Pronote+` ou `Pronote +` dans le code et autre pour le remplacer par `Papillon`.
Mis à part les textes, il manque bien sûr les logos, mais ceux-ci n'étant pas à ma portée du fait que je n'ai pas les assets.
Également, le changement du nom de domaine.
+ Sûrement d'autres choses, mais j'ai fait de mon mieux 👍